### PR TITLE
Updating documentation on list pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ If you decide to launch your own webring with this tool, let me know and I'll li
 - (Optional) Customize pages by modifying the templates, located in the `data/templates` folder (by default). You can also use remote files as templates. See the "Templates" section below. 
 - (Optional) Add any additional files into the `data/assets` folder (by default). Everything in this folder will simply be copied over into the output directory. Here you can add extras like images, HTML/CSS, etc. 
 - Run `ringfairy` to generate the webring by writing HTML files containing the redirects. Each site will link to the next/previous site in the `websites.json` file, forming your webring!
-- Host the generated files on your preferred hosting platform. 
+- Host the generated files on your preferred hosting platform.
+- All ring participants only need to add simple `<a href>` links for `previous`, `next`, and main site.
 
 ## ⚙️ Command-Line Arguments
 

--- a/data/assets/styles.css
+++ b/data/assets/styles.css
@@ -59,6 +59,18 @@ th {
     padding: 12px;
 }
 
+.webring {
+	margin: auto;
+	width: 50%;
+	text-align: center;
+	font-size: 1.5em;
+}
+
+.instructions {
+	margin-left: 10%;
+	margin-right: 10%;
+}
+
 @media screen and (max-width: 600px) {
     table {
         width: 100%; /* Allows the table to be 100% width on smaller screens */

--- a/data/templates/list.html
+++ b/data/templates/list.html
@@ -19,7 +19,16 @@
 	<br>
 	<div class="instructions">
 	  <h2>Community Rules</h2>
+	  <ol>
+		<li>List of community rules.</li>
+		<li>Information about if/when a site maybe removed.</li>
+	  </ol>
 	  <h2>Joining Process</h2>
+	  <ol>
+		<li>List of steps to join.</li>
+		<li>Contact the list owner/create a pull request.</li>
+		<li>How to leave the ring.</li>
+	  </ol>
 	  <h2>Instructions</h2>
 	  After your site is on the list, you can add the webring to your site by pasting in the following and replacing YOUR_NAME exactly as it appears in the table above:
 	  <pre>

--- a/data/templates/list.html
+++ b/data/templates/list.html
@@ -2,22 +2,43 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<link rel="stylesheet" href="./styles.css">
-<head>
+  <link rel="stylesheet" href="./styles.css">
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Webring List</title>
-</head>
-<body>
-    <h1>Webring List</h1>
+  </head>
+  <body>
+	<h1>Webring List</h1>
+	<div class="webring">
+	  <p> Current list of webrings.</p>
+	</div>
 
     {{ table_of_sites | safe}}
 
-
-<br>
-<footer>
-<p>Last updated: {{ current_time }} </p>
-<p>Powered by ringfairy!</p>
-</footer>
-</body>
+	<br>
+	<div class="instructions">
+	  <h2>Community Rules</h2>
+	  <h2>Joining Process</h2>
+	  <h2>Instructions</h2>
+	  After your site is on the list, you can add the webring to your site by pasting in the following and replacing YOUR_NAME exactly as it appears in the table above:
+	  <pre>
+&lt;style&gt;
+  .webring {
+	  margin: auto;
+	  width: 50%;
+	  text-align: center;}
+&lt;/style&gt;
+&lt;div class="webring"&gt;
+  &lt;a href="https://webring.domain.tld/YOUR_NAME/previous"&gt;←&lt;/a&gt; &nbsp;
+  &lt;a href="https://webring.domain.tld/"&gt;webring&lt;/a&gt; &nbsp;
+  &lt;a href="https://webring.domain.tld/YOUR_NAME/next"&gt;→&lt;/a&gt;
+&lt;/div&gt;
+	  </pre>
+	</div>
+	<footer>
+	  <p>Last updated: {{ current_time }} </p>
+	  <p>Powered by <a href="https://github.com/k3rs3d/ringfairy">ringfairy!</a></p>
+	</footer>
+  </body>
 </html>


### PR DESCRIPTION
Added more documentation to help an user setup the list page by prompting them with the information that the ring site owners would need.

Links are denoted as `https://webring.domain.tld/YOUR_NAME` but if `{{ url }}` was available then that would make the generated documentation custom to that specific ring. Perhaps a future feature?

Feel free to make any changes to the content/style, maintainer edits are enabled.
