### PR TITLE
Handled edge case: url containing // since that's a valid url scheme

### DIFF
--- a/src/website.rs
+++ b/src/website.rs
@@ -233,7 +233,9 @@ async fn does_html_contain_links(
 fn normalize_url(base_url: &str, url: &str) -> Result<String, Box<dyn std::error::Error>> {
     // Try to parse the URL (If it's an absolute URL, this will succeed)
     // otherwise this will fail and we'll attempt to resolve against the base URL
-    let parsed_url_result = reqwest::Url::parse(url);
+    // Double slashes are technically valid, replace with single slash to normalize
+    let processed_url = url.replace("//", "/").to_owned();
+    let parsed_url_result = reqwest::Url::parse(processed_url.as_str());
     
     let mut url = match parsed_url_result {
         Ok(url) => url, // If parsing succeeded, it's absolute


### PR DESCRIPTION
There are scenarios where an url can contain two slashes after the tld. It's more likely that the site adding the ring has accidentally added extra slashes. However, that leads to the audit of site to fail. Since two slashes is a valid url scheme and in the other scenario a misconfigured url in the linking site could break the ring. To make the audit more tolerant, I've proposed replacing double slashes with a single slash for the site audit functionality.
If this feature is desirable I will work on emitting warnings, look at more edges cases, etc.  