### PR TITLE
Mockito audit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +345,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "const-str"
@@ -1258,6 +1278,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6e023aa5bdf392aa06c78e4a4e6d498baab5138d0c993503350ebbc37bf1e"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "futures-core",
+ "hyper",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1865,7 @@ dependencies = [
  "lazy_static",
  "log",
  "minify-html",
+ "mockito",
  "opml",
  "rand",
  "regex",
@@ -2092,6 +2132,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ opt-level = 3
 strip = true
 debug = false
 panic = "abort"
+
+[dev-dependencies]
+mockito = "1.4.0"

--- a/src/gen/tests.rs
+++ b/src/gen/tests.rs
@@ -1,11 +1,13 @@
 use super::*;
 use crate::cli::AppSettings;
-use crate::gen::webring::*;
 use crate::gen::html::*;
-use crate::website::Website;
+use crate::gen::webring::*;
+use crate::http;
+use crate::website;
+use crate::website::*;
 use std::path::PathBuf;
 
-// Webring 
+// Webring
 
 fn create_sample_website(slug: &str, url: &str) -> Website {
     Website {
@@ -130,9 +132,7 @@ async fn test_verify_duplicate_urls() {
 
 #[tokio::test]
 async fn test_verify_empty_url() {
-    let websites = vec![
-        create_sample_website("site1", ""),
-    ];
+    let websites = vec![create_sample_website("site1", "")];
 
     let result = verify_websites(&websites);
     assert!(result.is_err());
@@ -140,9 +140,7 @@ async fn test_verify_empty_url() {
 
 #[tokio::test]
 async fn test_verify_invalid_url() {
-    let websites = vec![
-        create_sample_website("site1", "htp/invalid-url"),
-    ];
+    let websites = vec![create_sample_website("site1", "htp/invalid-url")];
 
     let result = verify_websites(&websites);
     assert!(result.is_err());
@@ -226,4 +224,38 @@ async fn test_ensure_output_directory() {
     assert!(Path::new(path).exists());
 
     fs::remove_dir_all(path).unwrap();
+}
+
+#[tokio::test]
+async fn test_audit_websites() {
+    let settings = mock_app_settings();
+    let audit_client = http::setup_client(&settings).await.unwrap(); // reqwest client
+    let mut mock_server = mockito::Server::new_async().await; // mockito server
+    let url = mock_server.url();
+    let mock_site = website::Website {
+        slug: "test".to_string(),
+        name: Some("Mock Website".to_string()),
+        about: Some("A test site for the webring".to_string()),
+        url: url.clone(),
+        rss: None,
+        owner: Some("Ralph H. Goo".to_string()),
+    };
+    let mock = mock_server
+        .mock("GET", "/")
+        .with_status(200)
+        .with_header("content-type", "text/html")
+        .with_body(r#"
+<a href="https://example.com/test/prev/">←</a>
+<a href="https://example.com/">Test Ring</a>
+<a href="https://example.com/test/next/">→</a>
+        "#) // TODO put actual html in the response body with webring links
+        .create();
+
+    let result = website::does_html_contain_links(&audit_client, &mock_site, &settings).await;
+
+    mock.assert_async().await; // Verify that mock was called
+    assert!(result.is_ok()); // Mock response should return Ok
+    
+    // TODO call audit function website::audit_links
+    //        -> verify function returns correctly audited sites
 }

--- a/src/website.rs
+++ b/src/website.rs
@@ -71,7 +71,7 @@ pub async fn audit_links(
     Ok(compliant_sites)
 }
 
-async fn does_html_contain_links(
+pub async fn does_html_contain_links(
     client: &reqwest::Client,
     website: &Website,
     settings: &AppSettings,


### PR DESCRIPTION
- Adds mockito as a dev dependency
- Adds the `test_audit_websites` test
  - Creates a mock HTTP server with an HTML response mocking a webring site
  - Checks if ringfairy can actually connect to a server and parse HTML for the correct links
  - Doesn't currently run the actual audit function - could be amended to also verify that ringfairy properly filters out noncompliant sites