### PR TITLE
Added new html layout using CSS grids instead of html tables.

### DIFF
--- a/data/assets/styles.css
+++ b/data/assets/styles.css
@@ -3,7 +3,7 @@ body {
 	line-height: 1.6;
     background-color: #111;
     color: #fff;
-	max-width: 80rem;
+	max-width: 80%;
 	margin: auto;
 }
 
@@ -92,3 +92,45 @@ th {
     }
 
 }
+:root {
+  --card-border: #446868;
+  --card-link-color: #88bebe;
+}
+.cards-container {
+		width: 90%;
+		margin-left: auto;
+		margin-right: auto;
+}
+.cards-container a {
+		color: var(--card-link-color);
+}
+.cards {
+		display: grid;
+		grid-gap: 0.5rem;
+		grid-template-columns: repeat(auto-fit, minmax(25rem, 1fr));
+}
+.card {
+		border: 2px solid var(--card-border);
+		border-radius: 0.5rem;
+}
+.card-name {
+		background-color: var(--card-border);
+		font-size: 1.25rem;
+		padding: 0.25rem; 
+		border-radius: 0.25rem 0.25rem 0 0;
+		text-transform: lowercase;
+}
+.card-content {
+		padding: 0.5rem;
+}
+.card-link {
+		font-size: .95rem;
+		text-transform: lowercase;
+}
+.card-text {
+		font-size: 0.75rem;
+}
+.card-slug {
+		font-size: 0.75rem;
+}
+

--- a/data/templates/grid.html
+++ b/data/templates/grid.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+	<link rel="stylesheet" href="./styles.css">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>{{ ring_name }} List</title>
+	</head>
+	<body>
+		<div class="cards-container">
+		<h1>{{ ring_name }} List</h1>
+			<p>{{ ring_description }}</p>
+			<p>Add all sites with declared RSS feeds to your feed reader with this <a href ="{{ opml }}">OPML</a> link.</p>
+
+			{{ grid_of_sites | safe}}
+
+			<br>
+			<footer>
+				<p>Last updated: {{ current_time }} </p>
+				<p>Powered by <a href="https://github.com/k3rs3d/ringfairy">ringfairy</a>!</p>
+			</footer>
+		</div>
+  </body>
+</html>

--- a/src/gen/html.rs
+++ b/src/gen/html.rs
@@ -208,6 +208,7 @@ impl HtmlGenerator {
         // Many of these are redundant 
         // Keeping them for compatibility (for now)
         context.insert("table_of_sites", &build_sites_table_html(websites).await);
+        context.insert("grid_of_sites", &build_sites_grid_html(websites).await);
         context.insert("base_url", &settings.base_url);
         context.insert("ring_name", &settings.ring_name);
         context.insert("ring_description", &settings.ring_description);
@@ -263,6 +264,33 @@ pub async fn build_sites_table_html(websites: &[WebringSite]) -> String {
     table_html
 }
 
+pub async fn build_sites_grid_html(websites: &[WebringSite]) -> String {
+		// Layout using CSS grid
+		let mut grid_html = String::new();
+		grid_html.push_str("<section class=\"cards\">\n");
+		for (index, website) in websites.iter().enumerate() {
+				grid_html.push_str("<article class=\"card\">\n");
+				grid_html.push_str(&format!("<div class=\"card-name\">{} <span class=\"card-slug\">({})</span></div>\n",
+																		website.website.owner.as_deref().map(format_owner).unwrap_or(String::new()),
+																		website.website.slug));
+				grid_html.push_str("<div class=\"card-content\">\n");
+				grid_html.push_str(&format!("<div class=\"card-link\"><a href=\"{}\" target=\"_blank\">{}</a>&nbsp;{}</div>\n",
+																		website.website.url,
+																		website.website.url,
+																		if let Some(rss_url) = &website.website.rss {
+																				format!(" <a href=\"{}\" target=\"_blank\">[rss]</a>", rss_url)
+																		} else {
+																				String::new()
+																		}
+				));
+				grid_html.push_str(&format!("<div class=\"card-text\">{}</div>\n",
+																		website.website.about.as_deref().unwrap_or("")));
+				grid_html.push_str("</div>\n"); //div card-content
+				grid_html.push_str("</article>\n");
+		}
+		grid_html.push_str("</section>");
+		grid_html
+}
 // TODO: make async?
 pub fn format_owner(owner: &str) -> String {
     owner


### PR DESCRIPTION
CSS grids makes the page layout more responsive for smaller screens. Using a pure CSS card style paradigm where each site gets a card with a name, link, and text element which can all be individually styled via CSS alone. Added a new layout page grid.html to demonstrate functionality and added to styles.css (which could be split-up to a seperate cards.css to isolate functionality).