### PR TITLE
Add "misc" field to website info for more control over the template system

### DIFF
--- a/src/gen/tests.rs
+++ b/src/gen/tests.rs
@@ -17,6 +17,7 @@ fn create_sample_website(slug: &str, url: &str) -> Website {
         url: url.to_string(),
         rss: Some(format!("http://{}.tld/rss", slug)),
         owner: Some(format!("Owner {}", slug)),
+        misc: None,
     }
 }
 
@@ -159,6 +160,7 @@ fn mock_webring_site() -> Vec<WebringSite> {
                 about: Some("About Site 1".to_string()),
                 owner: Some("owner1".to_string()),
                 rss: Some("https://site1.com/rss".to_string()),
+                misc: None,
             },
             previous: 1,
             next: 1,
@@ -171,6 +173,7 @@ fn mock_webring_site() -> Vec<WebringSite> {
                 about: Some("About Site 2".to_string()),
                 owner: Some("owner2".to_string()),
                 rss: Some("https://site2.com/rss".to_string()),
+                misc: None,
             },
             previous: 0,
             next: 0,

--- a/src/website.rs
+++ b/src/website.rs
@@ -1,5 +1,6 @@
 use futures::stream::{FuturesUnordered, StreamExt};
 use serde::{Deserialize, Serialize};
+use tera::Value;
 use std::result::Result;
 
 use crate::cli::AppSettings;
@@ -13,6 +14,7 @@ pub struct Website {
     pub url: String,
     pub rss: Option<String>,
     pub owner: Option<String>,
+    pub misc: Option<Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
For a webring I'm making for a group of friends, I wanted to add more metadata to each website in `websites.json`/`.toml`. e.g. a custom colour or image per site on the index page.

I thought my changes might be useful for others so here they are!

```toml
[[websites]]
name ="Example 1 Site"
slug = "Example1"
about = "Example Website 1!"
url = "https://example1.com"
owner = "owner 1"

  [websites.misc]
  colour = "#FF00FF"
```
or
```json
[
  {
    "name": "Example 1 Site",
    "slug": "Example1",
    "about": "Example Website 1!",
    "url": "https://example1.com",
    "owner": "owner 1",
    "misc": {
      "colour": "#FF00FF"
    }
  },
]
```
then use the field from the template code like
```html
{% for site in sites %}
  {{ site.website.misc.colour }}<br>
{% endfor %}
```