### PR TITLE
Manually convert errors to string

### DIFF
--- a/src/format_errors.rs
+++ b/src/format_errors.rs
@@ -1,0 +1,14 @@
+use crate::error::Error;
+
+pub fn format_error(err: Error) -> String {
+    match err {
+        Error::TemplateError(error) => error.to_string(),
+        Error::HttpError(error) => error.to_string(),
+        Error::ConfigError(error) => error.to_string(),
+        Error::IOError(error) => error.to_string(),
+        Error::Utf8Error(error) => error.to_string(),
+        Error::JsonError(error) => error.to_string(),
+        Error::TOMLError(error) => error.to_string(),
+        Error::StringError(error) => error.to_string(),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 mod cli;
 mod error;
 mod file;
+mod format_errors;
 mod gen;
 mod http;
 mod website;
 
-#[tokio::main]
-async fn main() -> Result<(), error::Error> {
+async fn run_ringfairy() -> Result<(), error::Error> {
     // Parse arguments & get settings struct
     let settings = cli::parse_args().await?;
 
@@ -25,4 +25,12 @@ async fn main() -> Result<(), error::Error> {
     log::info!("Done in {} ms!", elapsed.as_millis());
 
     Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run_ringfairy().await {
+        println!("{}", format_errors::format_error(err));
+        std::process::exit(1);
+    };
 }


### PR DESCRIPTION
This PR adds a format error function to give more control over how errors are displayed. Although this does not add much right now, the code I'm adding here can be extended to give more consistent and pretty errors for the entire project.